### PR TITLE
Add glossary to explain jargon

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -43,7 +43,8 @@ function builddocs(clear=false)
             "FAQ" => "faq.md",
             "Userfacing API" => "interfaces.md",
             "Benchmarks" => "benchmarks.md",
-            "API Reference" => "api.md"
+            "API Reference" => "api.md",
+            "Glossary" => "glossary.md"
         ]
     )
 end

--- a/docs/src/Examples/stateful.md
+++ b/docs/src/Examples/stateful.md
@@ -87,11 +87,22 @@ Generating a sequence of operations is simply generating a vector from all possi
 our property. We declare that for all sequences of operations we can do with a `Jug`, all invariants we expect
 must hold true.
 
+!!! tip "Invariants & Properties"
+    So far, we've only seen properties (i.e., predicate functions that return a `Bool`) that we'd
+    like to test with `@check`. Here, we use an [invariant](https://en.wikipedia.org/wiki/Invariant_(mathematics)),
+    which is a predicate function that must *always* be `true` for all inputs, no matter what we do with that
+    input. If we can ever find an input where the invariant isn't `true`, we have found a
+    counterexample for the overall property!
+
 Speaking of invariants, we need three of them that must be preserved at all times:
 
   1) The small jug must ALWAYS have a fill level between 0 and 3 (inclusive).
   2) The large jug must ALWAYS have a fill level between 0 and 5 (inclusive).
   3) The large just must NEVER have a fill level of exactly 4.
+
+The first two predicates are a result of the problem statement, which defines that we have two jugs of different
+sizes with some fill level. The upper bound is from either being large or small, and the lower bound of `0` is from
+not being able to have a negative fill level.
 
 The last invariant may look a bit odd, but remember that Supposition.jl is trying to find a _falsifying_ example.
 The first two invariants are sanity checks to make sure that our pouring functions are well behaved; the last

--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -1,5 +1,28 @@
 # FAQ
 
+## [What exactly is "shrinking"?](@id faq_shrinking)
+
+At a very high level, "shrinking" refers to the (sometimes quite abstract) process of minimizing an input in some
+context-specific manner towards a "smaller" example. For instance, if we have a property that takes in a
+`Vector` and we have some `Vector` that makes the property fail, Supposition.jl will try to find a vector with fewer elements.
+Similarly, for `String`s Supposition.jl will try to find a string with fewer characters, as well as strings whose
+characters have smaller unicode codepoints. For a property that takes a number, Supposition.jl will try to find a smaller number,
+and so on for other types. The exact metric by which an example is considered to be smaller is highly dependent on how it's
+been generated, so it's hard to write that down generically.
+
+How this works internally so that different `Possibility` can be composed well while preserving shrinking behavior
+is a bit more complicated. Internally, Supposition.jl keeps track of all choices made while generating a value
+in a so called _choice sequence_, in the order they occured in. While shrinking, Supposition.jl tries to remove
+choices in that sequence and feeds that modified sequence back into the `Possibility` you're using to generate
+your input. If the `Possibility` you're using can use that modified choice sequence and don't reject it,
+they will produce a shrunk value. For example, by removing choices a `Data.Vectors` consumes fewer choices from the
+choice sequence, which will result in a `Vector` with fewer elements.
+
+How exactly the choices in the choice sequence are mapped to output elements is an implementation detail, specific
+to each `Possibility`. In this way, it's possible to define custom shrinking orders by defining custom `Possibility`
+subtypes. For example, you could write a `Possibility` for integers that tries to *grow* the integer numerically, instead of
+shrinking it towards zero.
+
 ## Why write a new package? What about PropCheck.jl?
 
 PropCheck.jl is based on the Haskell library Hedgehog, while Supposition.jl is based on Hypothesis.

--- a/docs/src/glossary.md
+++ b/docs/src/glossary.md
@@ -8,7 +8,7 @@ frameworks.
 ### Generator
 
 A generator in the context of Supposition.jl is any object capable of producing objects
-by following the interface required by [`Possibility`](@ref).
+by following the interface required by [`Data.Possibility`](@ref).
 
 ### Choice Sequence
 
@@ -18,7 +18,7 @@ be made. For an `Int32`, it's 32 individual choices and so on for other number t
 For composite types, the recorded choices are an aggregate of the choices required for composition,
 as well as the choices of each individual object the composite type will be created out of.
 
-Some [`Possibility`](@ref), such as [`Data.Just`](@ref), don't require any choices to be made, since
+Some [`Data.Possibility`](@ref), such as [`Data.Just`](@ref), don't require any choices to be made, since
 they always produce the same value.
 
 As an example, generating a value from `Data.Integers(0x0, 0xf)` may lead to this choice sequence:
@@ -61,7 +61,7 @@ program, analysis of the output stream or detected segmentation faults.
 ### Structured Fuzzing
 
 Most programs operate on more than just random streams of bytes and require some structure to their input.
-In the context of Supposition.jl this means composing various [`Possibility`](@ref) into more complex
+In the context of Supposition.jl this means composing various [`Data.Possibility`](@ref) into more complex
 generators, which "stacks" the guarantees provided on the produced output. By producing more complex
 objects, the "stream of random bytes" effectively gains more structure, reducing the number of rejections
 due to trivially rejectable input.

--- a/docs/src/glossary.md
+++ b/docs/src/glossary.md
@@ -1,0 +1,116 @@
+# Glossary
+
+Property Based Testing has a lot of jargon associated with it, so this page contains
+a small glossary explaining the most commonly used terms. Their definitions are written
+down in the context of Supposition.jl, and may deviate slightly from their use in other
+frameworks.
+
+### Generator
+
+A generator in the context of Supposition.jl is any object capable of producing objects
+by following the interface required by [`Possibility`](@ref).
+
+### Choice Sequence
+
+Supposition.jl records any decision taken while generating a counterexample to a choice sequence.
+For example, in order to generate an `Int64`, 64 individual choices (one for each bit) need to
+be made. For an `Int32`, it's 32 individual choices and so on for other number types.
+For composite types, the recorded choices are an aggregate of the choices required for composition,
+as well as the choices of each individual object the composite type will be created out of.
+
+Some [`Possibility`](@ref), such as [`Data.Just`](@ref), don't require any choices to be made, since
+they always produce the same value.
+
+As an example, generating a value from `Data.Integers(0x0, 0xf)` may lead to this choice sequence:
+
+```
+UInt[ 0x5 ]
+```
+
+I.e. it records that the produced value was `0x5` (internally, the choice sequence
+is currently modelled as a `Vector{UInt64}`, though this is an implementation detail).
+
+Another possible choice sequence is is `[ 0x4 ]`, another is `[ 0x1 ]`, another (and minimal) is `[ 0x0 ]`.
+The bitstring representations of these are `00000100`, `00000001` and `00000000`
+respectively.
+
+How exactly this choice sequence is mapped to producing a value depends on
+the `Possibility` in use - for this `Data.Integers` example, the value is given
+directly. For others, like `Float64`, the mapping is more complicated.
+
+### Fuzzing
+
+"Fuzzing" refers to the process of generating random input to a function or program and executing
+that function with that randomly generated input. A program that generates such random input is
+called a "fuzzer".
+
+There are various complexity grades of fuzzers. Some rely on purely random generation and some take
+additional information into account to guide the random generation into more desirable directions.
+The general goal of any fuzzer is to explore the entire codebase through its random input,
+trying to find some failure condition (traditionally: segmentation faults).
+
+### Unstructured Fuzzing 
+
+There is also a distinction to be made between structured and unstructured fuzzing. Traditional
+fuzzers like [American Fuzzy Lop (AFL)](https://github.com/google/AFL) started out as treating the input as a pure stream
+of bytes, leaving the fuzzer to discover any additional requirements on the input by itself. This
+stream of random bytes is fed to the program under test, which then either accepts or rejects the
+input in some manner. Traditionally, this is detected with either return codes of the executed
+program, analysis of the output stream or detected segmentation faults.
+
+### Structured Fuzzing
+
+Most programs operate on more than just random streams of bytes and require some structure to their input.
+In the context of Supposition.jl this means composing various [`Possibility`](@ref) into more complex
+generators, which "stacks" the guarantees provided on the produced output. By producing more complex
+objects, the "stream of random bytes" effectively gains more structure, reducing the number of rejections
+due to trivially rejectable input.
+
+This has the effect of requiring less work of the fuzzer to find "well formed" inputs that the program
+accepts, making it easier to explore a larger portion of the codebase.
+
+In addition to giving more structure to the generated examples, by creating actual objects directly it becomes possible to
+not just give an input through the standard input stream, but also through calling various functions directly.
+This allows to check more program/function specific failure cases, not just exit codes or segmentation faults.
+
+### Property Based Testing
+
+Property Based Testing (PBT) refers to a testing technique where a program is tested not just with small hardcoded
+inputs, but with randomly generated input. Because the random input can make it impossible to make an exact comparison
+with an expected value, what is usually tested instead of the exact output is a _property_ that the output (or the program!)
+should have after the function currently being tested is called on the generated input.
+
+For instance, after calling `lowercase` on a string, every individual character of the output should be in lower case.
+Or after calling lowercase once, repeated calls of `lowercase` should not result in different strings.
+
+### Property
+
+A property is a boolean predicate that an object can have. For example, some `UInt8` have the property `iseven` (they are even numbers).
+As another example, some `String` have the property `isascii` (they consist of only ASCII characters).
+
+In the context of `@check`, a property is a predicate that the programmer wants a given transform/function call to have.
+Here, `@check` tries to check that the desired property actually holds.
+
+### Invariant
+
+An invariant is a boolean predicate that holds for _all_ objects of a given type. For example, `x -> 0 <= x <= 255` is
+true for all `UInt8`, thus the property is an invariant for `UInt8`. In contrast, this property is NOT an invariant
+for `UInt16`, because there are values in `UInt16` that are larger than `255`.
+
+A generator such as `ints = Data.Integers{UInt8}()` guarantees to _always_ produce `UInt8`; this is an invariant of the generator.
+Similarly, a generator such as `map(x -> 0x2 * x, ints)` guarantees to _always_ produce `UInt8` that are even numbers, because
+`x -> 0x2 * x` makes any number even by multiplying it with `0x2`.
+Composing generators composes the invariants the input generator provides, with the invariants the composed function
+provides. Through this, it is possible to create generators than can guarantee quite a lot of interesting & useful properties.
+
+### Shrinking
+
+Shrinking refers to the process of removing choices in the choice sequence in order to produce a "smaller" example
+that makes a property fail in the same way as the original example (built from the original choice sequence) did.
+Additionally, Supposition.jl considers shorter choice sequences better than longer ones, because that means that
+fewer choices were necessary to produce a failing input.
+
+How a given produce _value_ shrinks depends on how the mapping from the choice sequence to that value is implemented.
+Generally though, numbers tend to shrink towards smaller values (e.g. `UInt` and `Float64` shrink towards zero),
+collections shrink towards empty collections (`Vector`s shrink to empty vectors, `Dict`s to empty dicts with minimal keys & values)
+etc.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -7,7 +7,26 @@ It features choice-sequence based generation & shrinking of examples, which can 
 initial failures to smaller example while preserving the invariants the original input was generated
 under. It's also easy to combine generators into new generators.
 
-Check out the Examples in the sidebar to get an introduction to property based testing and to learn how to write your own tests!
+Regular unit testing can be viewed as a sequence of
+
+ 1. First, set up some data
+ 2. Manipulate the data in some way
+ 3. Assert something about the result (e.g. equality with an expected output)
+
+while Supposition.jl treats this flow like
+
+ 1. Generate a random (valid) input
+ 2. Manipulate that input in some way
+ 3. Assert something about the result and/or check that some property holds
+
+This is often called property based testing (PBT). For more information about why you may want to
+test your library in this way, have a look at [the introduction to PBT](@ref pbt_intro).
+
+In addition to providing facilities for generating random input, Supposition.jl also tries
+to simplify any found inputs to make them easier to handle when debugging the failure.
+
+For specific useage example of Supposition.jl, give the `Examples` in the sidebar a look! They contain common
+PBT patterns that can often generalize.
 
 Here's also a sitemap for the rest of the documentation:
 

--- a/docs/src/interfaces.md
+++ b/docs/src/interfaces.md
@@ -28,8 +28,8 @@ Supposition.@composed
 ## API for controlling fuzzing
 
 These functions are intended for usage while testing, having various effects
-on the shrinking/fuzzing process. They are not intended to be part
-of a codebase permanently/in production.
+on either the shrinking or fuzzing process. They are not intended to be part
+of a codebase permanently or remain active while deployed in production.
 
 The trailing exclamation mark serves as a reminder that this will, under
 the hood, modify the currently running testcase.

--- a/docs/src/intro.md
+++ b/docs/src/intro.md
@@ -1,4 +1,4 @@
-# Introduction
+# [Introduction](@id pbt_intro)
 
 What follows is a short introduction to what Property Based Testing (PBT) is from my POV. This may not be exhaustive - if you want a more formal
 or deeper dive into this topic, I can greatly recommend [this](https://hypothesis.works/articles/what-is-property-based-testing/) article
@@ -22,7 +22,7 @@ Now that I have your attention, let's get started:
 ## What is Property Based Testing?
 
 Property Based Testing is the idea of checking the correctness of a function, algorithm or calculation against a number of desired properties that function
-should observe. Consider this function:
+should observe. Consider this example of a property, a function that returns a `Bool`:
 
 ```julia
 function foo(a::Int, b::Int)
@@ -32,6 +32,7 @@ function foo(a::Int, b::Int)
 end
 ```
 
+This is also called a [predicate function](https://stackoverflow.com/questions/3230944/what-does-predicate-mean-in-the-context-of-computer-science).
 From reading the source code as a user, we can see that
 
   1) `a` and `b` must be of type `Int`
@@ -71,8 +72,10 @@ advantage of being _much, much faster_ than checking all possible values. We tra
 values). If our sampling is good enough & representative of the actual data we'd usually expect, this can be a very good indicator for
 correctness on our input. The difficulty comes from the second point above - controlling the values we put in to a satisfying degree,
 as well as, once a failure is found, reducing it to something we humans can more easily use to pinpoint the uncovered bug, through a process
-called "shrinking". You can find the introductory explanations for how this works in the context of Supposition.jl in the [Basic Usage](@ref)
+called "shrinking". You can find the introductory explanations for how this is done in the context of Supposition.jl in the [Basic Usage](@ref)
 section of the examples.
+
+For more information about shrinking, see [What exactly is "shrinking"?](@ref faq_shrinking).
 
 ## Julia specific nuances
 


### PR DESCRIPTION
This adds a number of things

 * A basic glossary of jargon, serving as a reference point to give a definition of jargon
 * Clarify wording in some sections
 * Add clarifying notes about invariants to the section on stateful testing

@moble please let me know if I've missed something!

Closes #35 
