### PR TITLE
generate floats using lexographically ordered encoding

### DIFF
--- a/src/data.jl
+++ b/src/data.jl
@@ -39,7 +39,7 @@ as well as these utility functions:
 module Data
 
 using Supposition
-using Supposition: smootherstep, lerp, TestCase, choice!, weighted!, forced_choice!, reject
+using Supposition: smootherstep, lerp, TestCase, choice!, weighted!, forced_choice!, reject, max_exponent, bias, assemble, tear, exposize, fracsize
 using RequiredInterfaces: @required
 using StyledStrings: @styled_str
 using Printf: format, @format_str
@@ -1449,9 +1449,118 @@ function Base.show(io::IO, ::MIME"text/plain", f::Floats)
     E.g. {code:$obj}; {code:isinf}: $inf, {code:isnan}: $nan""")
 end
 
+"""
+    exponent_key(T, e)
+
+A lexographical ordering for floating point exponents. The encoding is taken
+from hypothesis.
+The ordering is
+- non-negative exponents in increasing order
+- negative exponents in decreasing order
+- the maximum exponent
+"""
+function exponent_key(::Type{T}, e::iT) where {T<:Base.IEEEFloat,iT<:Unsigned}
+    if e == max_exponent(T)
+        return Inf
+    end
+    unbiased = float(e) - bias(T)
+    if unbiased < 0
+        10000 - unbiased
+    else
+        unbiased
+    end
+end
+
+_make_encoding_table(T) = sort(
+    zero(Supposition.uint(T)):max_exponent(T),
+    by=x -> exponent_key(T, x))
+const ENCODING_TABLE = Dict(
+    UInt16 => _make_encoding_table(Float16),
+    UInt32 => _make_encoding_table(Float32),
+    UInt64 => _make_encoding_table(Float64))
+
+
+"""
+    update_mantissa(exponent, mantissa)
+
+Encode the mantissa of a floating point number using an encoding with better shrinking.
+
+"""
+function update_mantissa(::Type{T}, exponent::iT, mantissa::iT)::iT where {T<:Base.IEEEFloat,iT<:Unsigned}
+    @assert Supposition.uint(T) == iT
+    # The unbiased exponent is <= 0
+    if exponent <= bias(T)
+        # reverse the bits of the mantissa in place
+        bitreverse(mantissa) >> (exposize(T) + 1)
+    elseif exponent >= fracsize(T) + bias(T)
+        mantissa
+    else
+        # reverse the low bits of the fractional part
+        # as determined by the exponent
+        n_reverse_bits = fracsize(T) + bias(T) - exponent
+        # isolate the bits to be reversed
+        to_reverse = mantissa & iT((1 << n_reverse_bits) - 1)
+        # zero them out
+        mantissa = mantissa ⊻ to_reverse
+        # reverse them and put them back in place
+        mantissa |= bitreverse(to_reverse) >> (8 * sizeof(T) - n_reverse_bits)
+    end
+end
+
+
+"""
+    lexographical_float(T, bits)
+
+Reinterpret the bits of a floating point number using an encoding with better shrinking
+properties.
+This produces a non-negative floating point number, possibly including NaN or Inf.
+
+The encoding is taken from hypothesis, and has the property that lexicographically smaller
+bit patterns corespond to 'simpler' floats.
+
+# Encoding
+
+The encoding used is as follows:
+
+If the sign bit is set: 
+
+    - the remainder of the first byte is ignored
+    - the remaining bytes are interpreted as an integer and converted to a float
+
+If the sign bit is not set:
+
+    - the exponent is decoded using `decode_exponent`
+    - the mantissa is updated using `update_mantissa`
+    - the float is reassembled using `assemble`
+
+"""
+function lexographical_float(::Type{T}, bits::I)::T where {I,T<:Base.IEEEFloat}
+    sizeof(T) == sizeof(I) || throw(ArgumentError("The bitwidth of `$T` needs to match the bidwidth of `I`!"))
+    iT = Supposition.uint(T)
+    sign, exponent, mantissa = tear(reinterpret(T, bits))
+    if sign == 1
+        exponent = ENCODING_TABLE[iT][exponent+1]
+        mantissa = update_mantissa(T, exponent, mantissa)
+        assemble(T, zero(iT), exponent, mantissa)
+    else
+        integral_mask = iT((1 << (8 * (sizeof(T) - 1))) - 1)
+        integral_part = bits & integral_mask
+        T(integral_part)
+    end
+end
+
 function produce!(tc::TestCase, f::Floats{T}) where {T}
     iT = Supposition.uint(T)
-    res = reinterpret(T, produce!(tc, Integers{iT}()))
+
+    bits = produce!(tc, Integers{iT}())
+
+    is_negative = produce!(tc, Booleans())
+
+    res = lexographical_float(T, bits)
+    if is_negative
+        res = -res
+    end
+
     # early rejections
     !f.infs && isinf(res) && reject(tc)
     !f.nans && isnan(res) && reject(tc)

--- a/src/util.jl
+++ b/src/util.jl
@@ -26,6 +26,9 @@ exposize(::Type{Float16}) = 5
 exposize(::Type{Float32}) = 8
 exposize(::Type{Float64}) = 11
 
+max_exponent(::Type{T}) where {T<:Base.IEEEFloat} = uint(T)(1 << exposize(T) - 1)
+bias(::Type{T}) where {T<:Base.IEEEFloat} = uint(T)(1 << (exposize(T) - 1) - 1)
+
 function masks(::Type{T}) where T <: Base.IEEEFloat
     ui = uint(T)
     signbitmask = one(ui) << (8*sizeof(ui)-1)


### PR DESCRIPTION
## PR Description

This implements an encoding of floating point numbers which is more amenable to nice shrinking as discussed in #22.

The basic idea is to reinterpret unsigned integers in a manner somewhat similar to the IEE754 encoding, but modified such that smaller `UInt`s correspond to "simpler" floats.

The encoding is a port of the one used in [Hypothesis](https://github.com/HypothesisWorks/hypothesis/blob/aad70fb2d9dec2cef9719cdf5369eec9fae0d2a4/hypothesis-python/src/hypothesis/internal/conjecture/floats.py#L176)

### PR Checklist

 - [ ] Tests written
 - [ ] Documentation expanded
 - [ ] Feature ready for review (if false, please mark the PR as `Draft`!)
