### PR TITLE
Support docstrings on @check property functions

### DIFF
--- a/src/api.jl
+++ b/src/api.jl
@@ -204,21 +204,30 @@ macro check(args...)
     isempty(args) && throw(ArgumentError("No arguments supplied to `@check`! Please refer to the documentation for usage information."))
     func = last(args)
     kw_args = collect(args[begin:end-1])
+
+    # Extract a docstring immediately preceding the function definition,
+    # e.g. @check "doc" function f(x=gen) ... end
+    docstring = nothing
+    if !isempty(kw_args) && last(kw_args) isa AbstractString
+        docstring = pop!(kw_args)
+    end
+
     opts = similar(kw_args, Any)
     opts .= kw_args
     if isexpr(func, :function, 2)
-        check_func(func, opts)
+        check_func(func, opts; docstring)
     elseif isexpr(func, :call)
+        docstring !== nothing && throw(ArgumentError("Docstring can only be attached to a function definition, not a function call!"))
         check_call(func, opts)
     elseif isexpr(func, Symbol("->")) | isexpr(func, Symbol("="), 2)
         func = anon_to_func(func)
-        check_func(func, opts)
+        check_func(func, opts; docstring)
     else
         throw(ArgumentError("Given expression is not a function call or definition!"))
     end
 end
 
-function check_func(e::Expr, tsargs)
+function check_func(e::Expr, tsargs; docstring=nothing)
     isexpr(e, :function, 2) || throw(ArgumentError("Given expression is not a function expression!"))
     head, body = e.args
     isexpr(head, :call) || throw(ArgumentError("Given expression is not a function head expression!"))
@@ -242,6 +251,11 @@ function check_func(e::Expr, tsargs)
     pushfirst!(funchead.args, name)
     push!(testfunc.args, funchead)
     push!(testfunc.args, body)
+
+    # Attach docstring if provided
+    if docstring !== nothing
+        testfunc = Expr(:macrocall, GlobalRef(Core, Symbol("@doc")), nothing, docstring, testfunc)
+    end
 
     pushfirst!(tsargs, :(record_base = $string($namestr, $argtypes($Base.promote_op($gen_input, $TestCase)))))
     final_block = final_check_block(namestr, run_input, gen_input, tsargs)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -586,6 +586,23 @@ const verb = VERSION.major == 1 && VERSION.minor < 11
             end
         end
 
+        @testset "docstring" begin
+            @with DEFAULT_CONFIG => API_conf begin
+                @check "Integers are integers." function docfunc(i=Data.Integers(0x0, 0xff))
+                    i isa Integer
+                end
+                @test contains(string(@doc docfunc), "Integers are integers.")
+
+                @check "Short form integers." docshort(i=Data.Integers(0x0, 0xff)) = i isa Integer
+                @test contains(string(@doc docshort), "Short form integers.")
+
+                @check verbose=verb "Adjacent to kwargs." function doc_adj(i=Data.Integers(0x0, 0xff))
+                    i isa Integer
+                end
+                @test contains(string(@doc doc_adj), "Adjacent to kwargs.")
+            end
+        end
+
         @testset "interdependent generation" begin
             Supposition.@check config=API_conf function depend(a=Data.Integers(0x0, 0xff), b=Data.Integers(a, 0xff))
                 a <= b


### PR DESCRIPTION
## Summary
- Support docstrings on `@check` property functions by placing a string literal immediately before the function definition, mirroring Julia's native docstring syntax
- Works with both long-form and short-form definitions, and composes with existing kwargs

```julia
@check "Length of empty vector is 0." function length_nil(x=Data.Just([]))
    length(x) == 0
end

@check "Short form." is_one(x=Data.Just(1)) = x == 1

@check verbose=true "With kwargs." function f(x=Data.Just(1))
    x == 1
end
```

Resolves https://github.com/Seelengrab/Supposition.jl/discussions/55

## Test plan
- [x] Existing 454 tests still pass
- [x] Long-form `function` definition with docstring
- [x] Short-form `=` definition with docstring
- [x] Docstring adjacent to other kwargs

🤖 Generated with [Claude Code](https://claude.com/claude-code)