### PR TITLE
Allow functions under `@check` to have docstrings.

### DIFF
--- a/src/api.jl
+++ b/src/api.jl
@@ -204,21 +204,26 @@ macro check(args...)
     isempty(args) && throw(ArgumentError("No arguments supplied to `@check`! Please refer to the documentation for usage information."))
     func = last(args)
     kw_args = collect(args[begin:end-1])
+    docstring = if !isempty(kw_args) && last(kw_args) isa AbstractString
+        pop!(kw_args)
+    else
+        nothing
+    end
     opts = similar(kw_args, Any)
     opts .= kw_args
     if isexpr(func, :function, 2)
-        check_func(func, opts)
+        check_func(func, opts; docstring)
+    elseif isexpr(func, Symbol("="), 2) | isexpr(func, Symbol("->"))
+        func = normalize_func(func)
+        check_func(func, opts; docstring)
     elseif isexpr(func, :call)
         check_call(func, opts)
-    elseif isexpr(func, Symbol("->")) | isexpr(func, Symbol("="), 2)
-        func = anon_to_func(func)
-        check_func(func, opts)
     else
         throw(ArgumentError("Given expression is not a function call or definition!"))
     end
 end
 
-function check_func(e::Expr, tsargs)
+function check_func(e::Expr, tsargs; docstring=nothing)
     isexpr(e, :function, 2) || throw(ArgumentError("Given expression is not a function expression!"))
     head, body = e.args
     isexpr(head, :call) || throw(ArgumentError("Given expression is not a function head expression!"))
@@ -242,6 +247,7 @@ function check_func(e::Expr, tsargs)
     pushfirst!(funchead.args, name)
     push!(testfunc.args, funchead)
     push!(testfunc.args, body)
+    testfunc = isnothing(docstring) ? testfunc : :(Base.@doc $docstring $testfunc)
 
     pushfirst!(tsargs, :(record_base = $string($namestr, $argtypes($Base.promote_op($gen_input, $TestCase)))))
     final_block = final_check_block(namestr, run_input, gen_input, tsargs)
@@ -470,7 +476,7 @@ macro composed(e::Expr)
     (isfunc | isanon | iscall) || throw(ArgumentError("Given expression is not a call or an (anonymous) function definition!"))
 
     if isanon
-        func = anon_to_func(e)
+        func = normalize_func(e)
         composed_from_func(func)
     elseif isfunc
         composed_from_func(e)
@@ -479,7 +485,7 @@ macro composed(e::Expr)
     end
 end
 
-function anon_to_func(e::Expr)
+function normalize_func(e::Expr)
     body = e.args[2]
     input = e.args[1]
 
@@ -549,7 +555,7 @@ function composed_from_call(e::Expr)
     prodname = QuoteNode(func)
 
     tc = gensym()
-    
+
     args = Expr(:tuple)
     for e in kwargs
         push!(args.args, :($Data.produce!($tc, $e)))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -734,6 +734,32 @@ const verb = VERSION.major == 1 && VERSION.minor < 11
             @test err.res isa Test.Error
             @test err.res.value == string(one_err)
         end
+
+        @testset "@check preserves function docstrings." begin
+            # On a function without a docstring, the doc is `nothing`.
+            @check function length_nil_undocumented(x=Data.Just(Int[]))
+                length(x) == 0
+            end
+            @test isnothing(@doc length_nil_undocumented)
+
+            # Docstrings are applied.
+            @check "Length is zero." function length_nil_long(x=Data.Just(Int[]))
+                length(x) == 0
+            end
+            @test only((@doc length_nil_long).text) == "Length is zero."
+            @check "Length is zero." length_nil_short(x=Data.Just(Int[])) =
+                length(x) == 0
+            @test only((@doc length_nil_short).text) == "Length is zero."
+
+            # Docstrings are preserved in the presence of keyword arguments:
+            @check verbose=false "Length is zero." function length_nil_long_kw(x=Data.Just(Int[]))
+                length(x) == 0
+            end
+            @test only((@doc length_nil_long_kw).text) == "Length is zero."
+            @check verbose=false "Length is zero." length_nil_short_kw(x=Data.Just(Int[])) = length(x) == 0
+            @test only((@doc length_nil_short_kw).text) == "Length is zero."
+        end
+
     end
 
     @testset "@composed API" begin


### PR DESCRIPTION
The docstring is popped out of the keyword list and applied to the test function. This works with and without `@check` keyword arguments, on long-form `function f() ... end` definitions and short-form `f() = ...` defintions.

I also renamed `anon_to_func` to `normalize_func` because it normalizes short-form function expressions too, not just anonymous ones.